### PR TITLE
Fix SYSTEM sessions

### DIFF
--- a/snowkill/engine.py
+++ b/snowkill/engine.py
@@ -28,7 +28,6 @@ from snowkill.struct import (
     Session,
     HoldingLock,
     User,
-    dataclass_to_json_str,
 )
 
 
@@ -286,7 +285,7 @@ class SnowKillEngine:
                 session_id=s["idAsString"],
                 client_application=s["clientApplication"],
                 client_environment=self._try_parse_json(s["clientEnvironment"]),
-                client_net_address=IPv4Address(s["clientNetAddress"]),
+                client_net_address=IPv4Address(s["clientNetAddress"]) if s["clientNetAddress"] is not None else None,
                 client_support_info=s["clientSupportInfo"],
                 user_name=s["userName"],
             )
@@ -498,6 +497,8 @@ class SnowKillEngine:
         )
 
     def _try_parse_json(self, val: str):
+        if val is None:
+            return {}
         try:
             return json_loads(val)
         except JSONDecodeError:

--- a/snowkill/struct.py
+++ b/snowkill/struct.py
@@ -26,7 +26,7 @@ class Session:
 
     client_application: str
     client_environment: Dict[str, Any]
-    client_net_address: IPv4Address
+    client_net_address: Optional[IPv4Address]
     client_support_info: str
 
     user_name: str


### PR DESCRIPTION
Hello @littleK0i,

Been using this library for a year. It's great!

That said, it sometimes randomly fails. I was able to look into why today and realized it's because `SYSTEM` sessions (e.g. updating a dynamic table) don't have an IP address or a client environment.

The changes in this PR fix the issue.

(The deleting of `dataclass_to_json_str` is because ruff told me it was an unused import)